### PR TITLE
add hints for go mod users in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Initialize BindataFS for your project, set the path you want to store BindataFS 
 $ bindatafs config/bindatafs
 ```
 
+Note that the program searches for templates in the `$GOPATH + src/github.com/qor/bindatafs/templates`. As a result, if using *gomodules* initialization will throw 404 errors. The recommended solution is to switch off go modules before running above commands and then switch it back on later.
+
 ## Usage
 
 ```go


### PR DESCRIPTION
With more and more organisations using go mod if would be helpful to give a hint about what can go wrong.
I had to look at source code to figure out whats going wrong with the steps. Fortunately, it was (unexpectedly) small that allowed to quickly understand the process. 